### PR TITLE
fixed return and response pass

### DIFF
--- a/demo/http_client.cpp
+++ b/demo/http_client.cpp
@@ -4,8 +4,7 @@
 #include <memory>
 
 int main() {
-    net::TcpClient::SharedPtr tcp_client = std::make_shared<net::TcpClient>("127.0.0.1", "8080");
-    net::HttpClient client(tcp_client);
+    net::HttpClient client("127.0.0.1", "8080");
 
     auto err = client.connect_server();
     if (err.has_value()) {

--- a/demo/https_client.cpp
+++ b/demo/https_client.cpp
@@ -21,9 +21,7 @@ int main() {
 
     ctx->set_certificates(execDir + "/template/keys/certificate.crt", execDir + "/template/keys/private.key");
 
-    net::SSLClient::SharedPtr ssl_client = std::make_shared<net::SSLClient>(ctx, "127.0.0.1", "8080");
-
-    net::HttpClient client(ssl_client);
+    net::HttpClient client("127.0.0.1", "8080", ctx);
 
     client.connect_server();
 

--- a/demo/websocket_client.cpp
+++ b/demo/websocket_client.cpp
@@ -6,9 +6,7 @@
 #include <thread>
 
 int main() {
-    net::TcpClient::SharedPtr socket_client = std::make_shared<net::TcpClient>("127.0.0.1", "8080");
-
-    net::WebSocketClient client(socket_client);
+    net::WebSocketClient client("127.0.0.1", "8080");
 
     client.connect_server();
 

--- a/net/application/http_client.cpp
+++ b/net/application/http_client.cpp
@@ -12,9 +12,13 @@
 
 namespace net {
 
-HttpClient::HttpClient(std::shared_ptr<TcpClient> client) {
-    m_parser = std::make_shared<HttpParser>();
-    m_client = std::move(client);
+HttpClient::HttpClient(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx):
+    m_parser(std::make_shared<HttpParser>()) {
+    if (ctx) {
+        m_client = std::make_shared<SSLClient>(ctx, ip, service);
+    } else {
+        m_client = std::make_shared<TcpClient>(ip, service);
+    }
 }
 
 std::optional<NetError> HttpClient::read_http(HttpResponse& res) {
@@ -359,6 +363,5 @@ std::string HttpClient::get_service() const {
 SocketStatus HttpClient::status() const {
     return m_client->status();
 }
-
 
 } // namespace net

--- a/net/application/http_client.cpp
+++ b/net/application/http_client.cpp
@@ -360,8 +360,5 @@ SocketStatus HttpClient::status() const {
     return m_client->status();
 }
 
-std::shared_ptr<HttpClient> HttpClient::get_shared() {
-    return shared_from_this();
-}
 
 } // namespace net

--- a/net/application/http_client.cpp
+++ b/net/application/http_client.cpp
@@ -57,12 +57,11 @@ std::optional<NetError> HttpClient::get(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_get(
@@ -89,12 +88,11 @@ std::optional<NetError> HttpClient::post(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_post(
@@ -122,12 +120,11 @@ std::optional<NetError> HttpClient::put(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_put(
@@ -154,12 +151,11 @@ std::optional<NetError> HttpClient::del(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_del(
@@ -186,12 +182,11 @@ std::optional<NetError> HttpClient::patch(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_patch(
@@ -218,12 +213,11 @@ std::optional<NetError> HttpClient::head(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_head(
@@ -249,12 +243,11 @@ std::optional<NetError> HttpClient::options(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_options(
@@ -280,12 +273,11 @@ std::optional<NetError> HttpClient::connect(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_connect(
@@ -311,12 +303,11 @@ std::optional<NetError> HttpClient::trace(
     if (err.has_value()) {
         return err;
     }
-    HttpResponse res;
-    err = read_http(res);
+    err = read_http(response);
     if (err.has_value()) {
         return err;
     }
-    std::nullopt;
+    return std::nullopt;
 }
 
 std::future<std::optional<NetError>> HttpClient::async_trace(

--- a/net/application/http_server.cpp
+++ b/net/application/http_server.cpp
@@ -218,10 +218,6 @@ std::shared_ptr<TcpServer> HttpServer::convert2tcp() {
     return std::move(m_server);
 }
 
-std::shared_ptr<HttpServer> HttpServer::get_shared() {
-    return shared_from_this();
-}
-
 void HttpServer::erase_parser(int remote_fd) {
     std::lock_guard<std::mutex> lock_guard(m_parsers_mutex);
     m_parsers.erase(remote_fd);

--- a/net/application/include/http_client.hpp
+++ b/net/application/include/http_client.hpp
@@ -4,6 +4,7 @@
 #include "remote_target.hpp"
 #include "socket_base.hpp"
 #include "ssl.hpp"
+#include "ssl_utils.hpp"
 #include "tcp.hpp"
 #include <future>
 #include <memory>
@@ -16,7 +17,7 @@ class HttpClient {
 public:
     NET_DECLARE_PTRS(HttpClient)
 
-    HttpClient(std::shared_ptr<TcpClient> client);
+    HttpClient(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx = nullptr);
 
     HttpClient(const HttpClient&) = delete;
 

--- a/net/application/include/http_client.hpp
+++ b/net/application/include/http_client.hpp
@@ -12,7 +12,7 @@
 
 namespace net {
 
-class HttpClient: public std::enable_shared_from_this<HttpClient> {
+class HttpClient {
 public:
     NET_DECLARE_PTRS(HttpClient)
 
@@ -174,8 +174,6 @@ public:
     std::string get_service() const;
 
     SocketStatus status() const;
-
-    std::shared_ptr<HttpClient> get_shared();
 
 protected:
     std::shared_ptr<HttpParser> m_parser;

--- a/net/application/include/http_server.hpp
+++ b/net/application/include/http_server.hpp
@@ -24,7 +24,7 @@ namespace net {
  * @note if you need to handle http failure, you can add error handler, and throw HttpResponseCode in your handler if 
  *       you want to response with error code, and the server will call the error handler you set
  */
-class HttpServer: public std::enable_shared_from_this<HttpServer> {
+class HttpServer {
 public:
     NET_DECLARE_PTRS(HttpServer)
 
@@ -77,8 +77,6 @@ public:
     std::string get_service() const;
 
     SocketStatus status() const;
-
-    std::shared_ptr<HttpServer> get_shared();
 
     virtual void add_error_handler(HttpResponseCode err_code, std::function<HttpResponse(const HttpRequest&)> handler);
 

--- a/net/application/include/websocket.hpp
+++ b/net/application/include/websocket.hpp
@@ -25,7 +25,7 @@ class WebSocketClient: public HttpClient {
 public:
     NET_DECLARE_PTRS(WebSocketClient)
 
-    WebSocketClient(std::shared_ptr<TcpClient> client);
+    WebSocketClient(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx = nullptr);
 
     std::optional<NetError> close();
 

--- a/net/application/websocket.cpp
+++ b/net/application/websocket.cpp
@@ -15,9 +15,9 @@
 
 namespace net {
 
-WebSocketClient::WebSocketClient(std::shared_ptr<TcpClient> client): HttpClient(client) {
-    m_parser = std::make_shared<WebSocketParser>();
-}
+WebSocketClient::WebSocketClient(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx):
+    HttpClient(ip, service, ctx),
+    m_parser(std::make_shared<WebSocketParser>()) {}
 
 std::optional<NetError> WebSocketClient::upgrade(const HttpRequest& upgrade_req) {
     HttpResponse res;

--- a/net/application/websocket.cpp
+++ b/net/application/websocket.cpp
@@ -265,10 +265,6 @@ std::optional<NetError> WebSocketClient::read_http(HttpResponse& res) {
     return HttpClient::read_http(res);
 }
 
-std::shared_ptr<WebSocketClient> WebSocketClient::get_shared() {
-    return std::static_pointer_cast<WebSocketClient>(HttpClient::get_shared());
-}
-
 /*************************WebSocket Server************************ */
 /*************************WebSocket Server************************ */
 /*************************WebSocket Server************************ */
@@ -493,10 +489,6 @@ void WebSocketServer::add_websocket_handler(std::function<void(RemoteTarget::Sha
 
 void WebSocketServer::allowed_path(const std::string& path) {
     m_allowed_paths.insert(path);
-}
-
-std::shared_ptr<WebSocketServer> WebSocketServer::get_shared() {
-    return std::static_pointer_cast<WebSocketServer>(HttpServer::get_shared());
 }
 
 std::optional<NetError>

--- a/net/socket/include/socket_base.hpp
+++ b/net/socket/include/socket_base.hpp
@@ -33,7 +33,7 @@ enum class SocketType : uint8_t {
 
 enum class SocketStatus { CONNECTED = 0, LISTENING, DISCONNECTED };
 
-class SocketClient: std::enable_shared_from_this<SocketClient> {
+class SocketClient {
 public:
     NET_DECLARE_PTRS(SocketClient)
 
@@ -56,8 +56,6 @@ public:
     std::optional<NetError> start_event_loop();
 
     virtual std::optional<NetError> close() = 0;
-
-    std::shared_ptr<SocketClient> get_shared();
 
     int get_fd() const;
 
@@ -91,7 +89,7 @@ protected:
     utils::LoggerManager::Logger m_logger;
 };
 
-class SocketServer: std::enable_shared_from_this<SocketServer> {
+class SocketServer {
     using CallBack = std::function<void(RemoteTarget::SharedPtr remote)>;
 
 public:
@@ -114,8 +112,6 @@ public:
     virtual std::optional<NetError> close() = 0;
 
     virtual std::optional<NetError> start() = 0;
-
-    std::shared_ptr<SocketServer> get_shared();
 
     int get_fd() const;
 
@@ -153,7 +149,6 @@ protected:
     virtual RemoteTarget::SharedPtr create_remote(int remote_fd) = 0;
 
     virtual void add_remote_event(int fd) = 0;
-
 
     std::optional<NetError> set_non_blocking_socket(int fd);
 

--- a/net/socket/include/ssl.hpp
+++ b/net/socket/include/ssl.hpp
@@ -40,8 +40,6 @@ public:
 
     std::optional<NetError> close() override;
 
-    std::shared_ptr<SSLClient> get_shared();
-
 protected:
     std::optional<NetError> ssl_connect(std::size_t time_out = 0);
 
@@ -65,8 +63,6 @@ public:
     std::optional<NetError> close() override;
 
     std::optional<NetError> listen() override;
-
-    std::shared_ptr<SSLServer> get_shared();
 
     std::optional<NetError> read(std::vector<uint8_t>& data, RemoteTarget::SharedPtr remote) override;
 

--- a/net/socket/include/tcp.hpp
+++ b/net/socket/include/tcp.hpp
@@ -29,8 +29,6 @@ public:
     std::optional<NetError> read(std::vector<uint8_t>& data, std::size_t time_out = 0) override;
 
     std::optional<NetError> write(const std::vector<uint8_t>& data, std::size_t time_out = 0) override;
-
-    std::shared_ptr<TcpClient> get_shared();
 };
 
 class TcpServer: public SocketServer {
@@ -54,8 +52,6 @@ public:
     std::optional<NetError> close() override;
 
     std::optional<NetError> start() override;
-
-    std::shared_ptr<TcpServer> get_shared();
 
     std::optional<NetError> read(std::vector<uint8_t>& data, RemoteTarget::SharedPtr remote) override;
 

--- a/net/socket/socket_base.cpp
+++ b/net/socket/socket_base.cpp
@@ -52,10 +52,6 @@ SocketStatus SocketClient::status() const {
     return m_status;
 }
 
-std::shared_ptr<SocketClient> SocketClient::get_shared() {
-    return shared_from_this();
-}
-
 std::optional<NetError> SocketClient::set_non_blocking_socket(int fd) {
     int flag = ::fcntl(fd, F_GETFL, 0);
     if (flag == -1) {
@@ -144,10 +140,6 @@ std::string SocketServer::get_service() const {
 
 SocketStatus SocketServer::status() const {
     return m_status;
-}
-
-std::shared_ptr<SocketServer> SocketServer::get_shared() {
-    return shared_from_this();
 }
 
 std::optional<NetError> SocketServer::set_non_blocking_socket(int fd) {

--- a/net/socket/ssl.cpp
+++ b/net/socket/ssl.cpp
@@ -176,10 +176,6 @@ std::optional<NetError> SSLClient::close() {
     return TcpClient::close();
 }
 
-std::shared_ptr<SSLClient> SSLClient::get_shared() {
-    return std::static_pointer_cast<SSLClient>(TcpClient::get_shared());
-}
-
 SSLServer::SSLServer(std::shared_ptr<SSLContext> ctx, const std::string& ip, const std::string& service):
     TcpServer(ip, service),
     m_ctx(std::move(ctx)) {}
@@ -336,9 +332,6 @@ RemoteTarget::SharedPtr SSLServer::create_remote(int remote_fd) {
     return remote;
 }
 
-std::shared_ptr<SSLServer> SSLServer::get_shared() {
-    return std::dynamic_pointer_cast<SSLServer>(TcpServer::get_shared());
-}
 
 bool SSLServer::handle_ssl_handshake(RemoteTarget::SharedPtr remote) {
     auto ssl_remote = std::dynamic_pointer_cast<SSLEvent>(remote);

--- a/net/socket/tcp.cpp
+++ b/net/socket/tcp.cpp
@@ -206,10 +206,6 @@ std::optional<NetError> TcpClient::write(const std::vector<uint8_t>& data, std::
     }
 }
 
-std::shared_ptr<TcpClient> TcpClient::get_shared() {
-    return std::static_pointer_cast<TcpClient>(SocketClient::get_shared());
-}
-
 TcpClient::~TcpClient() {
     if (m_status == SocketStatus::CONNECTED) {
         this->close();
@@ -476,10 +472,6 @@ void TcpServer::handle_connection(RemoteTarget::SharedPtr remote) {
 
 RemoteTarget::SharedPtr TcpServer::create_remote(int remote_fd) {
     return std::make_shared<RemoteTarget>(remote_fd);
-}
-
-std::shared_ptr<TcpServer> TcpServer::get_shared() {
-    return std::static_pointer_cast<TcpServer>(SocketServer::get_shared());
 }
 
 void TcpServer::add_remote_event(int client_fd) {


### PR DESCRIPTION
This pull request includes multiple changes to simplify the codebase by removing the use of `shared_from_this` and updating constructors to directly accept connection parameters. The most important changes include modifications to the `HttpClient` and `WebSocketClient` classes, as well as updates to the `SocketClient` and `SocketServer` classes.These changes streamline the code by eliminating unnecessary shared pointer management and simplifying object construction.