### PR TITLE
add http client group, clean websocket server

### DIFF
--- a/demo/http_client.cpp
+++ b/demo/http_client.cpp
@@ -5,6 +5,7 @@
 
 int main() {
     net::HttpClient client("127.0.0.1", "8080");
+    client.set_proxy("127.0.0.1", "3128");
 
     auto err = client.connect_server();
     if (err.has_value()) {

--- a/demo/http_server.cpp
+++ b/demo/http_server.cpp
@@ -27,8 +27,7 @@ std::string getExecutablePath() {
 }
 
 int main() {
-    net::TcpServer::SharedPtr tcp_server = std::make_shared<net::TcpServer>("127.0.0.1", "8080");
-    net::HttpServer server(tcp_server);
+    net::HttpServer server("127.0.0.1", "8080");
 
     auto err = server.listen();
     if (err.has_value()) {

--- a/demo/https_server.cpp
+++ b/demo/https_server.cpp
@@ -33,9 +33,7 @@ int main() {
 
     ctx->set_certificates(execDir + "/template/keys/certificate.crt", execDir + "/template/keys/private.key");
 
-    net::SSLServer::SharedPtr server = std::make_shared<net::SSLServer>(ctx, "127.0.0.1", "8080");
-
-    net::HttpServer http_server(server);
+    net::HttpServer http_server("127.0.0.1", "8080", ctx);
 
     http_server.listen();
 
@@ -58,7 +56,7 @@ int main() {
 
     while (true) {
         std::string input;
-            std::cin >> input;
+        std::cin >> input;
         // std::cout << "Received input: " << input << std::endl;
         if (input == "exit") {
             http_server.close();

--- a/demo/websocket_server.cpp
+++ b/demo/websocket_server.cpp
@@ -33,8 +33,6 @@ int main() {
     auto exe_path = getExecutablePath();
     auto execDir = std::filesystem::path(exe_path).parent_path().string();
 
-    net::TcpServer::SharedPtr tcp_server = std::make_shared<net::TcpServer>();
-
     net::WebSocketServer server("127.0.0.1", "8080");
 
     server.allowed_path("/");

--- a/demo/websocket_server.cpp
+++ b/demo/websocket_server.cpp
@@ -33,13 +33,12 @@ int main() {
     auto exe_path = getExecutablePath();
     auto execDir = std::filesystem::path(exe_path).parent_path().string();
 
-    net::TcpServer::SharedPtr tcp_server = std::make_shared<net::TcpServer>("127.0.0.1", "8080");
+    net::TcpServer::SharedPtr tcp_server = std::make_shared<net::TcpServer>();
 
-    tcp_server->enable_thread_pool(96);
-
-    net::WebSocketServer server(tcp_server);
+    net::WebSocketServer server("127.0.0.1", "8080");
 
     server.allowed_path("/");
+    server.enable_thread_pool(96);
 
     auto content = readFileToString(execDir + "/template/index/index.html");
     server.get("/", [&content](const net::HttpRequest& req) {

--- a/net/application/http_client.cpp
+++ b/net/application/http_client.cpp
@@ -1,7 +1,9 @@
 #include "http_client.hpp"
 #include "http_parser.hpp"
+#include "print.hpp"
 #include "ssl.hpp"
 #include "tcp.hpp"
+#include "websocket_utils.hpp"
 #include <algorithm>
 #include <cassert>
 #include <memory>
@@ -13,11 +15,14 @@
 namespace net {
 
 HttpClient::HttpClient(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx):
-    m_parser(std::make_shared<HttpParser>()) {
+    m_parser(std::make_shared<HttpParser>()),
+    m_target_ip(ip),
+    m_target_service(service),
+    m_ssl_ctx(ctx) {
     if (ctx) {
-        m_client = std::make_shared<SSLClient>(ctx, ip, service);
+        m_client = std::make_shared<SSLClient>(ctx, m_target_ip, m_target_service);
     } else {
-        m_client = std::make_shared<TcpClient>(ip, service);
+        m_client = std::make_shared<TcpClient>(m_target_ip, m_target_service);
     }
 }
 
@@ -38,6 +43,16 @@ std::optional<NetError> HttpClient::read_http(HttpResponse& res) {
 }
 
 std::optional<NetError> HttpClient::write_http(const HttpRequest& req) {
+    if (m_use_proxy) {
+        // Prepare the proxy request (for example, set the proxy URL and headers)
+        auto& proxy_req = const_cast<HttpRequest&>(req);
+        if (!m_proxy_username.empty() && !m_proxy_password.empty()) {
+            proxy_req.set_headers({ { "Proxy-Authorization",
+                                      "Basic " + base64_encode(m_proxy_username + ":" + m_proxy_password) } });
+        }
+        proxy_req.set_headers({ { "Host", m_target_ip + ":" + m_target_service } });
+        proxy_req.set_url("http://" + m_target_ip + ":" + m_target_service + req.url());
+    }
     auto buffer = m_parser->write_req(req);
     if (buffer.empty()) {
         return std::nullopt;
@@ -362,6 +377,37 @@ std::string HttpClient::get_service() const {
 
 SocketStatus HttpClient::status() const {
     return m_client->status();
+}
+
+void HttpClient::set_proxy(
+    const std::string& ip,
+    const std::string& service,
+    const std::string& username,
+    const std::string& password
+) {
+    m_use_proxy = true;
+    m_proxy_ip = ip;
+    m_proxy_service = service;
+    m_proxy_username = username;
+    m_proxy_password = password;
+    if (m_ssl_ctx) {
+        m_client = std::make_shared<SSLClient>(m_ssl_ctx, m_proxy_ip, m_proxy_service);
+    } else {
+        m_client = std::make_shared<TcpClient>(m_proxy_ip, m_proxy_service);
+    }
+}
+
+void HttpClient::unset_proxy() {
+    m_use_proxy = false;
+    m_proxy_ip.clear();
+    m_proxy_service.clear();
+    m_proxy_username.clear();
+    m_proxy_password.clear();
+    if (m_ssl_ctx) {
+        m_client = std::make_shared<SSLClient>(m_ssl_ctx, m_target_ip, m_target_service);
+    } else {
+        m_client = std::make_shared<TcpClient>(m_target_ip, m_target_service);
+    }
 }
 
 } // namespace net

--- a/net/application/http_server.cpp
+++ b/net/application/http_server.cpp
@@ -3,6 +3,7 @@
 #include "event_loop.hpp"
 #include "http_parser.hpp"
 #include "remote_target.hpp"
+#include "ssl.hpp"
 #include "timer.hpp"
 #include <cassert>
 #include <format>
@@ -19,15 +20,19 @@
 
 namespace net {
 
-HttpServer::HttpServer(std::shared_ptr<TcpServer> server):
+HttpServer::HttpServer(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx):
     m_handlers {
         { HttpMethod::GET, m_get_handlers },        { HttpMethod::POST, m_post_handlers },
         { HttpMethod::PUT, m_put_handlers },        { HttpMethod::TRACE, m_trace_handler },
         { HttpMethod::DELETE, m_delete_handlers },  { HttpMethod::OPTIONS, m_options_handler },
         { HttpMethod::CONNECT, m_connect_handler }, { HttpMethod::PATCH, m_patch_handler },
         { HttpMethod::HEAD, m_head_handler },
-    },
-    m_server(std::move(server)) {
+    } {
+    if (ctx) {
+        m_server = std::make_shared<SSLServer>(ip, service, ctx);
+    } else {
+        m_server = std::make_shared<TcpServer>(ip, service);
+    }
     set_handler();
 }
 

--- a/net/application/http_server.cpp
+++ b/net/application/http_server.cpp
@@ -29,7 +29,7 @@ HttpServer::HttpServer(const std::string& ip, const std::string& service, std::s
         { HttpMethod::HEAD, m_head_handler },
     } {
     if (ctx) {
-        m_server = std::make_shared<SSLServer>(ip, service, ctx);
+        m_server = std::make_shared<SSLServer>(ctx, ip, service);
     } else {
         m_server = std::make_shared<TcpServer>(ip, service);
     }

--- a/net/application/include/http_client.hpp
+++ b/net/application/include/http_client.hpp
@@ -176,9 +176,29 @@ public:
 
     SocketStatus status() const;
 
+    void set_proxy(
+        const std::string& ip,
+        const std::string& service,
+        const std::string& username = {},
+        const std::string& password = {}
+    );
+
+    void unset_proxy();
+
 protected:
     std::shared_ptr<HttpParser> m_parser;
     std::shared_ptr<TcpClient> m_client;
+
+    std::string m_target_ip;
+    std::string m_target_service;
+
+    bool m_use_proxy = false;
+    std::string m_proxy_ip;
+    std::string m_proxy_service;
+    std::string m_proxy_username;
+    std::string m_proxy_password;
+
+    std::shared_ptr<SSLContext> m_ssl_ctx;
 };
 
 } // namespace net

--- a/net/application/include/http_client.hpp
+++ b/net/application/include/http_client.hpp
@@ -7,9 +7,12 @@
 #include "ssl_utils.hpp"
 #include "tcp.hpp"
 #include <future>
+#include <map>
 #include <memory>
 #include <optional>
+#include <shared_mutex>
 #include <string>
+#include <tuple>
 
 namespace net {
 
@@ -199,6 +202,28 @@ protected:
     std::string m_proxy_password;
 
     std::shared_ptr<SSLContext> m_ssl_ctx;
+};
+
+class HttpClientGroup {
+public:
+    HttpClientGroup() = default;
+
+    std::optional<NetError> connect(const std::string& ip, const std::string& service);
+
+    std::optional<NetError> close(const std::string& ip, const std::string& service);
+
+    std::shared_ptr<HttpClient> get_client(const std::string& ip, const std::string& service);
+
+    std::optional<NetError> remove_client(const std::string& ip, const std::string& service);
+
+    std::optional<NetError>
+    add_client(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx = nullptr);
+
+    ~HttpClientGroup() = default;
+
+private:
+    std::shared_mutex m_mutex;
+    std::map<std::tuple<std::string, std::string>, std::shared_ptr<HttpClient>> m_clients;
 };
 
 } // namespace net

--- a/net/application/include/http_server.hpp
+++ b/net/application/include/http_server.hpp
@@ -28,7 +28,7 @@ class HttpServer {
 public:
     NET_DECLARE_PTRS(HttpServer)
 
-    HttpServer(std::shared_ptr<TcpServer> server);
+    HttpServer(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx = nullptr);
 
     HttpServer(const HttpServer&) = delete;
 
@@ -107,5 +107,7 @@ protected:
 
     std::shared_ptr<TcpServer> m_server;
 };
+
+class HttpServerForwardProxy: public HttpServer {};
 
 } // namespace net

--- a/net/application/include/websocket.hpp
+++ b/net/application/include/websocket.hpp
@@ -184,7 +184,7 @@ class WebSocketServer: public HttpServer {
 public:
     NET_DECLARE_PTRS(WebSocketServer)
 
-    WebSocketServer(std::shared_ptr<TcpServer> client);
+    WebSocketServer(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx = nullptr);
 
     ~WebSocketServer();
 

--- a/net/application/include/websocket.hpp
+++ b/net/application/include/websocket.hpp
@@ -188,27 +188,7 @@ public:
 
     ~WebSocketServer();
 
-    WebSocketStatus ws_status() const;
-
     SocketStatus status() const;
-
-    void get(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void post(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void put(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void del(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void head(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void trace(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void connect(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void options(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
-
-    void patch(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) override;
 
     void add_websocket_handler(std::function<void(RemoteTarget::SharedPtr remote)> handler);
 
@@ -233,7 +213,6 @@ private:
     std::mutex m_ws_parsers_mutex;
 
     std::function<void(RemoteTarget::SharedPtr remote)> m_ws_handler;
-    WebSocketStatus m_websocket_status = WebSocketStatus::DISCONNECTED;
 };
 
 } // namespace net

--- a/net/application/websocket.cpp
+++ b/net/application/websocket.cpp
@@ -273,7 +273,8 @@ std::optional<NetError> WebSocketClient::read_http(HttpResponse& res) {
 /*************************WebSocket Server************************ */
 /*************************WebSocket Server************************ */
 
-WebSocketServer::WebSocketServer(std::shared_ptr<TcpServer> server): HttpServer(server) {
+WebSocketServer::WebSocketServer(const std::string& ip, const std::string& service, std::shared_ptr<SSLContext> ctx):
+    HttpServer(ip, service, ctx) {
     set_handler();
 }
 

--- a/net/application/websocket.cpp
+++ b/net/application/websocket.cpp
@@ -282,50 +282,6 @@ SocketStatus WebSocketServer::status() const {
     return m_server->status();
 }
 
-void WebSocketServer::get(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::get(path, handler);
-}
-
-void WebSocketServer::post(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::post(path, handler);
-}
-
-void WebSocketServer::put(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::put(path, handler);
-}
-
-void WebSocketServer::del(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::del(path, handler);
-}
-
-void WebSocketServer::head(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::head(path, handler);
-}
-
-void WebSocketServer::trace(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::trace(path, handler);
-}
-
-void WebSocketServer::connect(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::connect(path, handler);
-}
-
-void WebSocketServer::options(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::options(path, handler);
-}
-
-void WebSocketServer::patch(const std::string path, std::function<HttpResponse(const HttpRequest&)> handler) {
-    assert(m_websocket_status != WebSocketStatus::CONNECTED && "Protocol has upgraded to websocket!");
-    HttpServer::patch(path, handler);
-}
 
 std::optional<NetError> WebSocketServer::accept_ws_connection(const HttpRequest& req, std::vector<uint8_t>& res) {
     if (req.headers().find("sec-websocket-key") == req.headers().end()) {
@@ -479,10 +435,6 @@ void WebSocketServer::erase_parser(int remote_fd) {
 }
 
 WebSocketServer::~WebSocketServer() {}
-
-WebSocketStatus WebSocketServer::ws_status() const {
-    return m_websocket_status;
-}
 
 void WebSocketServer::add_websocket_handler(std::function<void(RemoteTarget::SharedPtr remote)> handler) {
     m_ws_handler = std::move(handler);

--- a/net/common/include/defines.hpp
+++ b/net/common/include/defines.hpp
@@ -25,6 +25,8 @@ struct NetError {
 #define NET_INVALID_WEBSOCKET_UPGRADE_CODE 4
 #define NET_HTTP_PARSE_WANT_READ 5
 #define NET_EARLY_END_OF_SOCKET 6
+#define NET_NO_CLIENT_FOUND 7
+#define NET_CLIENT_ALREADY_EXISTS 8
 
 #define GET_ERROR_MSG() \
     NetError { errno, std::system_category().message(errno) }

--- a/net/socket/tcp.cpp
+++ b/net/socket/tcp.cpp
@@ -130,7 +130,7 @@ std::optional<NetError> TcpClient::read(std::vector<uint8_t>& data, std::size_t 
             return NetError { NET_TIMEOUT_CODE, "Timeout to read from socket" };
         }
         std::vector<uint8_t> buffer(1024);
-        num_bytes = ::recv(m_fd, buffer.data(), buffer.size(), 0);
+        num_bytes = ::recv(m_fd, buffer.data(), buffer.size(), MSG_NOSIGNAL);
         if (num_bytes == -1) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 if (data.size() <= 0) {
@@ -173,7 +173,7 @@ std::optional<NetError> TcpClient::write(const std::vector<uint8_t>& data, std::
             }
             return NetError { NET_TIMEOUT_CODE, "Timeout to write to socket" };
         }
-        ssize_t num_bytes = ::send(m_fd, data.data() + bytes_has_send, data.size() - bytes_has_send, 0);
+        ssize_t num_bytes = ::send(m_fd, data.data() + bytes_has_send, data.size() - bytes_has_send, MSG_NOSIGNAL);
         if (num_bytes == -1) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 if (bytes_has_send <= 0) {


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the HTTP and WebSocket server and client implementations. The most significant changes include adding proxy support to the `HttpClient`, refactoring server constructors to simplify their initialization, and removing redundant WebSocketServer methods.

### Proxy Support for HttpClient:
* Added `set_proxy` and `unset_proxy` methods to `HttpClient` to enable and disable proxy settings. [[1]](diffhunk://#diff-7fc8198f00b86395710e61a286174e68b2235ca5d74d7fef4eeb1e298b533d56R384-R469) [[2]](diffhunk://#diff-f550b9a2805aa8ab60fcb13072d9918ed4e6703b722a8563f190f59b64d7a8f3R182-R226)
* Modified `write_http` method to handle proxy requests by setting appropriate headers and URL.

### Server Initialization Refactoring:
* Refactored constructors of `HttpServer`, `WebSocketServer`, and `HttpClient` to accept IP, service, and optional SSL context parameters directly, simplifying the initialization process. [[1]](diffhunk://#diff-9f1364af90add366dd8ad04440d4a2b6f7b0fdd7ecf3afe8ada4748e129b3221L30-R30) [[2]](diffhunk://#diff-2f3e9797c6944a86c920fe57525bce5f2a9670751b69ea26c485a862276b3a46L36-R36) [[3]](diffhunk://#diff-bf0bc8bc409921f52b9478c86e24538c6495694338244fba0a4ec3eb8fe677a5L36-R39) [[4]](diffhunk://#diff-33825aa5f575cd3b47b1904002e2d8f22c29123f410dad0fdac3c1ecb0c926c1L22-R35) [[5]](diffhunk://#diff-43744c1120f6d2f272434e09108406a1c11e3685cb2dfa8ced5d6c123dec4260L31-R31) [[6]](diffhunk://#diff-90dff67eb635cba9bc974465d8c77473be34a12f8b8baa148950639db6d37edeL187-L212) [[7]](diffhunk://#diff-33ec8ff6949389fc7c15073906bd149124f0d6e0de9cd94eef8ec35b4f6d22a7L276-L327)

### Codebase Simplification:
* Removed redundant WebSocketServer methods that were overriding base `HttpServer` methods with assertions. [[1]](diffhunk://#diff-90dff67eb635cba9bc974465d8c77473be34a12f8b8baa148950639db6d37edeL236) [[2]](diffhunk://#diff-33ec8ff6949389fc7c15073906bd149124f0d6e0de9cd94eef8ec35b4f6d22a7L482-L485)
* Added missing includes in `http_client.cpp` and `http_server.cpp` for better modularity and dependency management. [[1]](diffhunk://#diff-7fc8198f00b86395710e61a286174e68b2235ca5d74d7fef4eeb1e298b533d56R2-R27) [[2]](diffhunk://#diff-33825aa5f575cd3b47b1904002e2d8f22c29123f410dad0fdac3c1ecb0c926c1R6)

### Error Handling Enhancements:
* Introduced new error codes `NET_NO_CLIENT_FOUND` and `NET_CLIENT_ALREADY_EXISTS` for better error reporting in `HttpClientGroup`.

### Socket Communication Improvement:
* Updated `TcpClient`'s `recv` and `send` calls to use `MSG_NOSIGNAL` flag to prevent SIGPIPE signals on socket operations. [[1]](diffhunk://#diff-247a0fff827fb5976adc4fdad7f51b5f365b8c9c1cd6be2177270234df508c6fL133-R133) [[2]](diffhunk://#diff-247a0fff827fb5976adc4fdad7f51b5f365b8c9c1cd6be2177270234df508c6fL176-R176)