### PR TITLE
fixed bug in http server

### DIFF
--- a/demo/http_client.cpp
+++ b/demo/http_client.cpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 int main() {
-    net::HttpClient client("www.baidu.com", "80");
+    net::HttpClient client("127.0.0.1", "8080");
     client.set_proxy("127.0.0.1", "2196");
 
     auto err = client.connect_server();


### PR DESCRIPTION
This pull request includes several changes to the `HttpClient` and `HttpServer` classes to improve functionality and error handling. The most significant changes include updating the `HttpClient` initialization parameters, adding a new include directive, and refining the `set_handler` method in `HttpServer`.

### HttpClient Changes:
* Updated the `HttpClient` initialization parameters to use `127.0.0.1` and port `8080` instead of the previous values.

### HttpServer Changes:
* Added a new include directive for `<functional>` to `http_server.cpp`.
* Refined the `set_handler` method to improve error handling:
  * Replaced the use of `std::unordered_map` iterator with a `std::function` for the handler.
  * Improved error handling for incorrect methods and paths, ensuring appropriate error responses are set. [[1]](diffhunk://#diff-33825aa5f575cd3b47b1904002e2d8f22c29123f410dad0fdac3c1ecb0c926c1L148-R163) [[2]](diffhunk://#diff-33825aa5f575cd3b47b1904002e2d8f22c29123f410dad0fdac3c1ecb0c926c1R173-R176)
  * Added comments to clarify the handling logic for correct methods and paths.
  * Ensured proper cleanup and response writing in the `set_handler` method. [[1]](diffhunk://#diff-33825aa5f575cd3b47b1904002e2d8f22c29123f410dad0fdac3c1ecb0c926c1R188-R189) [[2]](diffhunk://#diff-33825aa5f575cd3b47b1904002e2d8f22c29123f410dad0fdac3c1ecb0c926c1L194-R202)